### PR TITLE
Fix output of test results

### DIFF
--- a/bin/bashtub
+++ b/bin/bashtub
@@ -97,7 +97,7 @@ print_result() {
   printf '\n\n'
 
   if [[ ${#FAILED_CASES[@]} -eq 0 ]]; then
-    echo "$TEST_CASE_COUNT examples, 0 failure"
+    echo "$TEST_CASE_COUNT examples, 0 failures"
     return 0
   else
     echo "Failers:"
@@ -107,7 +107,7 @@ print_result() {
       printf "    \e[31m${FAILURE_REASONS[$i]}\e[m\n"
     }
     echo
-    printf "\e[31m$TEST_CASE_COUNT examples, $count failure\e[m\n"
+    printf "\e[31m$TEST_CASE_COUNT examples, ${#FAILED_CASES[@]} failures\e[m\n"
     return 1
   fi
 }

--- a/test/output_test.sh
+++ b/test/output_test.sh
@@ -1,0 +1,31 @@
+testcase_result_ontains_number_of_examples() {
+  local TMPFILE=$(mktemp)
+  echo '
+  testcase_my_test_case() {
+    assert_true true
+    assert_true true
+    assert_true true
+  }
+  ' >$TMPFILE
+  subject $0 $TMPFILE
+  assert_match '3 examples' "$stdout"
+  rm $TMPFILE
+}
+
+testcase_result_ontains_number_of_examples_and_failures() {
+  local TMPFILE=$(mktemp)
+  echo '
+  testcase_my_test_case() {
+    assert_true true
+    assert_true true
+    assert_true true
+    assert_true false
+    assert_true false
+  }
+  ' >$TMPFILE
+  subject $0 $TMPFILE
+  assert_match '5 examples' "$stdout"
+  assert_match '2 failures' "$stdout"
+  assert_match 'My test case' "$stdout"
+  rm $TMPFILE
+}


### PR DESCRIPTION
Change spell 'failure' to 'failures', and fix number of failures on output when any tests fail.
