### PR TITLE
Supporting multiple bash versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 sudo: false
 language: bash
+env:
+- RUN_BASH_VERSION=3.1
+- RUN_BASH_VERSION=3.2
+- RUN_BASH_VERSION=4.0
+- RUN_BASH_VERSION=4.1
+- RUN_BASH_VERSION=4.2
+- RUN_BASH_VERSION=4.3
+before_install:
+- bash bin/install_bash.sh
 script:
-- bash -e bin/bashtub `find test -name '*_test.sh'`
-- bash -eu bin/bashtub `find test -name '*_test.sh'`
+- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -e bin/bashtub `find test -name '*_test.sh'`
+- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -eu bin/bashtub `find test -name '*_test.sh'`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: bash
 script:
-- bash bin/bashtub `find test -name '*_test.sh'`
-- bash -u bin/bashtub `find test -name '*_test.sh'`
+- bash -e bin/bashtub `find test -name '*_test.sh'`
+- bash -eu bin/bashtub `find test -name '*_test.sh'`

--- a/bin/bashtub
+++ b/bin/bashtub
@@ -11,7 +11,7 @@ to_sentence() {
   declare space_separated
   space_separated=${1#testcase_}
   space_separated=${space_separated//_/ }
-  echo "${space_separated^}"
+  echo "$(tr '[:lower:]' '[:upper:]' <<< ${space_separated:0:1})${space_separated:1}"
 }
 
 assert_equal_matcher() {

--- a/bin/install_bash.sh
+++ b/bin/install_bash.sh
@@ -1,0 +1,6 @@
+[ -z ${RUN_BASH_VERSION+x} ] && exit 1
+
+curl "https://ftp.gnu.org/gnu/bash/bash-${RUN_BASH_VERSION}.tar.gz" | tar zx
+cd bash-${RUN_BASH_VERSION}
+./configure --prefix="$TRAVIS_BUILD_DIR/$RUN_BASH_VERSION"
+make -j4 install


### PR DESCRIPTION
Add tests for bash 3.X and 4.0, which close #14 
