### PR TITLE
Travis cache to improve test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
 before_install:
 - bash bin/install_bash.sh
 script:
+- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash --version
 - $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -e bin/bashtub `find test -name '*_test.sh'`
 - $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -eu bin/bashtub `find test -name '*_test.sh'`

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ env:
 - RUN_BASH_VERSION=4.3
 before_install:
 - bash bin/install_bash.sh
+cache:
+  directories:
+  - bash-build
 script:
-- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash --version
-- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -e bin/bashtub `find test -name '*_test.sh'`
-- $TRAVIS_BUILD_DIR/$RUN_BASH_VERSION/bin/bash -eu bin/bashtub `find test -name '*_test.sh'`
+- bash-build/$RUN_BASH_VERSION/bin/bash --version
+- bash-build/$RUN_BASH_VERSION/bin/bash -e bin/bashtub `find test -name '*_test.sh'`
+- bash-build/$RUN_BASH_VERSION/bin/bash -eu bin/bashtub `find test -name '*_test.sh'`

--- a/bin/install_bash.sh
+++ b/bin/install_bash.sh
@@ -1,6 +1,7 @@
 [ -z ${RUN_BASH_VERSION+x} ] && exit 1
+[ -f $TRAVIS_BUILD_DIR/bash-build/$RUN_BASH_VERSION/bin/bash ] && exit 0
 
 curl "https://ftp.gnu.org/gnu/bash/bash-${RUN_BASH_VERSION}.tar.gz" | tar zx
 cd bash-${RUN_BASH_VERSION}
-./configure --prefix="$TRAVIS_BUILD_DIR/$RUN_BASH_VERSION"
+./configure --prefix="$TRAVIS_BUILD_DIR/bash-build/$RUN_BASH_VERSION"
 make -j4 install


### PR DESCRIPTION
The compiled bash'es are cached in `bash-build`.  If specified bash already exists in cache, the build of bash is avoided.
