### PR TITLE
Modify parameter option to output error for short unrecognized option

### DIFF
--- a/bin/bashtub
+++ b/bin/bashtub
@@ -122,6 +122,7 @@ for param in "$@"; do
   --help) help_and_exit;;
   --version) version_and_exit;;
   --*) unrecognized_option_and_exit "${param#--}" ;;
+  -*) unrecognized_option_and_exit "${param#-}" ;;
   *) break ;;
   esac
   shift

--- a/test/paramter_option_test.sh
+++ b/test/paramter_option_test.sh
@@ -14,7 +14,14 @@ testcase_output_version() {
   assert_match 'bashtub' "$stdout"
 }
 
-testcase_output_unrecognized_option() {
+testcase_output_unrecognized_short_option() {
+  subject $0 -Z
+  assert_match 'unrecognized' "$stderr"
+  assert_match 'Z' "$stderr"
+  assert_equal 1 $status
+}
+
+testcase_output_unrecognized_long_option() {
   subject $0 --sushi
   assert_match 'unrecognized' "$stderr"
   assert_match 'sushi' "$stderr"


### PR DESCRIPTION
Output an error when unrecognized option is given, such as '-z'.
