### PR TITLE
Compatible for OS X

### DIFF
--- a/bin/bashtub
+++ b/bin/bashtub
@@ -46,9 +46,9 @@ located_assertion_base() {
   TEST_CASE_COUNT+=1
   reason=$($matcher "$@")
   if [[ $? -eq 0 ]]; then
-    echo -en '\e[32m.\e[m'
+    echo -n $'\e[32m.\e[m'
   else
-    echo -en "\e[31mF\e[m"
+    echo -n $'\e[31mF\e[m'
     FAILED_CASES=("${FAILED_CASES[@]}" "$case_name")
     FAILURE_LOCATIONS=("${FAILURE_LOCATIONS[@]}" "$location")
     FAILURE_REASONS=("${FAILURE_REASONS[@]}" "$reason")
@@ -69,12 +69,16 @@ print_result() {
   else
     echo "Failers:"
     for ((i = 0; i < ${#FAILED_CASES[@]}; ++i)) {
-      echo -e "$((i + 1))) ${FAILED_CASES[$i]}"
-      echo -e "    \e[31m${FAILURE_LOCATIONS[$i]}\e[m"
-      echo -e "    \e[31m${FAILURE_REASONS[$i]}\e[m"
+      echo "$((i + 1))) ${FAILED_CASES[$i]}"
+      echo -n $'\e[31m'
+      echo "    ${FAILURE_LOCATIONS[$i]}"
+      echo "    ${FAILURE_REASONS[$i]}"
+      echo -n $'\e[m'
     }
     echo
-    echo "\e[31m$TEST_CASE_COUNT examples, ${#FAILED_CASES[@]} failures\e[m"
+    echo -n $'\e[31m'
+    echo "$TEST_CASE_COUNT examples, ${#FAILED_CASES[@]} failures"
+    echo -n $'\e[m'
     return 1
   fi
 }

--- a/test/assertion_equal_test.sh
+++ b/test/assertion_equal_test.sh
@@ -1,5 +1,5 @@
 testcase_comapres_numbers() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_equal 10 $((2 + 8))
   }' >$TMPFILE
@@ -8,7 +8,7 @@ testcase_comapres_numbers() {
 }
 
 testcase_comapres_spaced_string() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_equal "alice bob" "alice bob"
   }' >$TMPFILE
@@ -17,7 +17,7 @@ testcase_comapres_spaced_string() {
 }
 
 testcase_unmatched_strings() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_equal "apple" "pineapple"
   }' >$TMPFILE

--- a/test/assertion_match_test.sh
+++ b/test/assertion_match_test.sh
@@ -1,5 +1,5 @@
 testcase_partialy_matches() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_match cdef abcdefgh
   }' >$TMPFILE
@@ -8,7 +8,7 @@ testcase_partialy_matches() {
 }
 
 testcase_matches_heads() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_match ^abc abcdefgh
   }' >$TMPFILE
@@ -17,7 +17,7 @@ testcase_matches_heads() {
 }
 
 testcase_matches_tails() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_match fgh$ abcdefgh
   }' >$TMPFILE
@@ -26,7 +26,7 @@ testcase_matches_tails() {
 }
 
 testcase_matches_with_spaces() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_match " is a " "This is a pen"
   }' >$TMPFILE
@@ -35,7 +35,7 @@ testcase_matches_with_spaces() {
 }
 
 testcase_not_matches_with_spaces() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_compare_numbers() {
     assert_match " is a " "This apple"
   }' >$TMPFILE

--- a/test/assertion_truth_test.sh
+++ b/test/assertion_truth_test.sh
@@ -1,5 +1,5 @@
 testcase_assertion_true_passes_with_number_comparison() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_assert_true() {
     assert_true [[ $((2 + 3)) -eq $((1 + 4)) ]]
   }' >$TMPFILE
@@ -8,7 +8,7 @@ testcase_assertion_true_passes_with_number_comparison() {
 }
 
 testcase_assertion_fails_with_inverted_truth() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_assert_true() {
     assert_true false
   }' >$TMPFILE
@@ -17,7 +17,7 @@ testcase_assertion_fails_with_inverted_truth() {
 }
 
 testcase_assertion_passes_with_assert_false() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo 'testcase_assert_true() {
     assert_false false
   }' >$TMPFILE

--- a/test/output_test.sh
+++ b/test/output_test.sh
@@ -1,5 +1,5 @@
 testcase_result_ontains_number_of_examples() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo '
   testcase_my_test_case() {
     assert_true true
@@ -13,7 +13,7 @@ testcase_result_ontains_number_of_examples() {
 }
 
 testcase_result_ontains_number_of_examples_and_failures() {
-  local TMPFILE=$(mktemp)
+  local TMPFILE=$(mktemp -t tmp.XXXXXX)
   echo '
   testcase_my_test_case() {
     assert_true true


### PR DESCRIPTION
Although OS X is available in Travis CI on probation (see http://docs.travis-ci.com/user/multi-os/), we will not set-up the OS X  to Travis. I confirmed to pass tests manually, only in bash 3.2.53, due to the fact that compiling a GNU bash is failed on OS X.  
