### PR TITLE
Change setup/teardown with before/after

### DIFF
--- a/bin/bashtub
+++ b/bin/bashtub
@@ -132,12 +132,16 @@ exec 3>$logfile
 for f in "$@"; do
   ( source "$f"
     hash setup 2>/dev/null && setup
+    hash before_all 2>/dev/null && before_all
     for testcase in $(compgen -A function | grep '^testcase_'); do
       ( source $logfile
+        hash before_each 2>/dev/null && before_each
         $testcase
+        hash after_each 2>/dev/null && after_each
         declare -p FAILED_CASES FAILURE_LOCATIONS FAILURE_REASONS TEST_CASE_COUNT >&3
       )
     done
+    hash after_all 2>/dev/null && after_all
     hash teardown 2>/dev/null && teardown
     true
   )

--- a/bin/bashtub
+++ b/bin/bashtub
@@ -131,7 +131,11 @@ exec 3>$logfile
 
 for f in "$@"; do
   ( source "$f"
-    hash setup 2>/dev/null && setup
+    hash setup 2>/dev/null && {
+      echo "setup is no longer supported in feature versions." >/dev/stderr
+      echo "Use before_each of before_all" >/dev/stderr
+      setup
+    }
     hash before_all 2>/dev/null && before_all
     for testcase in $(compgen -A function | grep '^testcase_'); do
       ( source $logfile
@@ -142,7 +146,11 @@ for f in "$@"; do
       )
     done
     hash after_all 2>/dev/null && after_all
-    hash teardown 2>/dev/null && teardown
+    hash teardown 2>/dev/null && {
+      echo "teardown is no longer supported in feature versions." >/dev/stderr
+      echo "Use after_each of after_all" >/dev/stderr
+      teardown
+    }
     true
   )
 done


### PR DESCRIPTION
`setup`/`teardown` is no longer supported.  They are replaced with `before_each`, `before_all`, `after_each`, and `after_all`.  `*_each` are invoked before/after each test cases, and `*_all` are invoked before/after all test cases.
