### PR TITLE
Do not execute the same executable file.

### DIFF
--- a/bin/bashtub
+++ b/bin/bashtub
@@ -131,22 +131,22 @@ exec 3>$logfile
 
 for f in "$@"; do
   ( source "$f"
-    hash setup 2>/dev/null && {
+    declare -f setup 2>/dev/null && {
       echo "setup is no longer supported in feature versions." >/dev/stderr
       echo "Use before_each of before_all" >/dev/stderr
       setup
     }
-    hash before_all 2>/dev/null && before_all
+    declare -f before_all 2>/dev/null && before_all
     for testcase in $(compgen -A function | grep '^testcase_'); do
       ( source $logfile
-        hash before_each 2>/dev/null && before_each
+        declare -f before_each 2>/dev/null && before_each
         $testcase
-        hash after_each 2>/dev/null && after_each
+        declare -f after_each 2>/dev/null && after_each
         declare -p FAILED_CASES FAILURE_LOCATIONS FAILURE_REASONS TEST_CASE_COUNT >&3
       )
     done
-    hash after_all 2>/dev/null && after_all
-    hash teardown 2>/dev/null && {
+    declare -f after_all 2>/dev/null && after_all
+    declare -f teardown 2>/dev/null && {
       echo "teardown is no longer supported in feature versions." >/dev/stderr
       echo "Use after_each of after_all" >/dev/stderr
       teardown


### PR DESCRIPTION
- Do not want to run `/usr/{bin,sbin}/setup` on CentOS.

for example: on CentOS 6.6
```
$ cat /etc/redhat-release
CentOS release 6.6 (Final)

$ yum provides /usr/bin/setup
# (omit)
setuptool-1.19.9-4.el6.x86_64 : A text mode system configuration tool
Repo        : base
Matched from:
Filename    : /usr/bin/setup
# (omit)
```